### PR TITLE
Changing bot name identification from case sensitive to case insensitive

### DIFF
--- a/irc-stream.js
+++ b/irc-stream.js
@@ -26,7 +26,7 @@ function IrcStream(server, name, ircOpts, opts) {
   // respond directly - in channel - to anything matching chanReg
   var registerChanHandler = function () {
     if (!opts.noChan) {
-      var chanReg = new RegExp('^' + name + '[\\s,\\:](.*)');
+      var chanReg = new RegExp('^' + name + '[\\s,\\:](.*)', 'i');
       this.bot.addListener('message', function (from, to, msg) {
         var reply = false;
         var content = '';


### PR DESCRIPTION
because
- the twitch.tv HTML chat window convert the first letter in all names to uppercase (f.e. "name" is changed to "Name"). Copying the bot name "Name" from that window to address it ("Name what do you think?") fail if we don't match the bot name case insensitive
